### PR TITLE
Add extensions to startwith, endswith etc.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-  - julia_version: 1.0
+  - julia_version: 1.2
   - julia_version: nightly
 platform:
   - x86

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,27 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
+  # we don't test on 1.0 as our tests use some
+  # 1.2 features (though the package itself doesn't)
+  - 1.2
+  - 1.3
+  - 1.4
   - nightly
-matrix:
+jobs::
   allow_failures:
-    - julia: nightly
+    - julia: 1.4, nightly
   fast_finish: true
-notifications:
-  email: false
-after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-jobs:
   include:
     - stage: Documentation
-      julia: 1.0
+      julia: 1
       script: julia --project=docs -e '
           using Pkg;
           Pkg.develop(PackageSpec(path=pwd()));
           Pkg.instantiate();
           include("docs/make.jl");'
       after_success: skip
+
+notifications:
+  email: false
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -90,3 +90,8 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Wrangling]]
+path = ".."
+uuid = "9e19721c-8a1a-4e7b-ae00-562464868f98"
+version = "0.1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Wrangling = "9e19721c-8a1a-4e7b-ae00-562464868f98"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,19 +5,20 @@ makedocs(;
     format=Documenter.HTML(),
     pages=[
         "Home" => "index.md",
-        "Working with Symbol" => "symbol_searching.md",
+        "Working with Symbols" => "symbol_searching.md",
         "API" => "api.md",
     ],
     repo="https://github.com/invenia/Wrangling.jl/blob/{commit}{path}#L{line}",
     sitename="Wrangling.jl",
     authors="Invenia Technical Computing Corporation",
-    assets=[
+    #== assets=[
         "assets/invenia.css",
         "assets/logo.png",
-    ],
-    #strict=true,
+    ],==#
+    strict=true,
 )
 
 deploydocs(;
     repo="github.com/invenia/Wrangling.jl",
+    push_preview=true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,8 @@ makedocs(;
     format=Documenter.HTML(),
     pages=[
         "Home" => "index.md",
+        "Working with Symbol" => "symbol_searching.md",
+        "API" => "api.md",
     ],
     repo="https://github.com/invenia/Wrangling.jl/blob/{commit}{path}#L{line}",
     sitename="Wrangling.jl",
@@ -13,6 +15,7 @@ makedocs(;
         "assets/invenia.css",
         "assets/logo.png",
     ],
+    #strict=true,
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,10 +11,6 @@ makedocs(;
     repo="https://github.com/invenia/Wrangling.jl/blob/{commit}{path}#L{line}",
     sitename="Wrangling.jl",
     authors="Invenia Technical Computing Corporation",
-    #== assets=[
-        "assets/invenia.css",
-        "assets/logo.png",
-    ],==#
     strict=true,
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,7 @@
+# API
+```@index
+```
+
+```@autodocs
+Modules = [Wrangling]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,3 +2,8 @@
 
 Wrangling.jl is a package to make data wrangling easier.
 It works well along side packages like [Tables.jl](https://github.com/JuliaData/Tables.jl) and [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl/).
+
+
+```@contents
+Pages = ["symbol_searching.md", "api.md"]
+``

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,4 @@
 # Wrangling.jl
 
-```@index
-```
-
-```@autodocs
-Modules = [Wrangling]
-```
+Wrangling.jl is a package to make data wrangling easier.
+It works well along side packages like [Tables.jl](https://github.com/JuliaData/Tables.jl) and [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl/).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,5 +5,4 @@ It works well along side packages like [Tables.jl](https://github.com/JuliaData/
 
 
 ```@contents
-Pages = ["symbol_searching.md", "api.md"]
-``
+```

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -24,7 +24,7 @@ We add the missing ones.
 ## Functions
 These are basically all varients of existing functions.
 
- [`contains(haystack, needle)`](@ref contains) is an argument order reversed version of `occursin(needle, haystack)`. It matchs `startswith` and `endswith`.
+ [`contains(haystack, needle)`](@ref contains) is an argument order reversed version of `occursin(needle, haystack)`. It matches `startswith` and `endswith`.
 
 `contains`, `startswith`, `endswith`, and all their varients mentioned here, accept `Symbol`s everywhere they might accept `String`s.
 

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -46,7 +46,7 @@ I might want just the columns names that are for a particular city:
 ```jldoctest symbol_searching
 julia> using Wrangling
 
-julia> const column_names = const column_names = [:NY_temperature, :NY_house_price, :NY_car_price, :NY_rainfall, :LON_temperature, :LON_house_price, :LON_car_price, :LON_rainfall];
+julia> const column_names =  [:NY_temperature, :NY_house_price, :NY_car_price, :NY_rainfall, :LON_temperature, :LON_house_price, :LON_car_price, :LON_rainfall];
 
 julia> const LON_cols = filter(startswith(:LON), column_names)
 4-element Array{Symbol,1}:

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -5,7 +5,7 @@ Often one thus wants to do various filters on `Symbol`s.
 
 Most filtering functions only accept strings, so code contains a lot of code like:
 ```julia
-filter(col_name->startswith(colname, "tempurature"), Symbol.(names(df)))
+filter(col_name->startswith(colname, "temperature"), Symbol.(names(df)))
 ```
 
 We solve that by making functions that accept `Symbol` for all the arguments that would otherwise be strings.
@@ -14,24 +14,24 @@ not all do.
 We add the missing ones.
 
 
-!!! warning Type Piracy
+!!! warning "Type Piracy"
     We type-pirate `startwith` and `endswith` to provide the single argument, and `Symbol` accepting versions.
     This is misdemeanor type-piracy: it only turns code which currently errors into nonerrors.
-    Its also the only reasonable definition for these types.
-    We don't type-pirate `occursin` as we replace that with `` which follows the consistent argument order.
+    It is also the only reasonable definition for these methods.
+    We don't type-pirate `occursin` as we replace that with [`contains`](@ref) which follows the consistent argument order.
 
 
-### Functions:
+## Functions
 These are basically all varients of existing functions.
 
- [`contains`](@ref)`(haystack, needle)` is an argument order reversed version of `occursin(needle, haystack)`. It matchs `startswith` and `endswith`.
+ [`contains(haystack, needle)`](@ref contains) is an argument order reversed version of `occursin(needle, haystack)`. It matchs `startswith` and `endswith`.
 
-`contains`, `startswith`, `endswith`, and all their varients mentioned here, all accept symbols everywhere they might accept `String`s.
+`contains`, `startswith`, `endswith`, and all their varients mentioned here, accept `Symbol`s everywhere they might accept `String`s.
 
 The curried varients are `check(needle) == haystack->check(haystack, needle)`.
 We have them for `contains`, `startswith`, `endswith`, and all their varients.
 
-The any varients are `startswith_any`, `endswith_any`,  and `contains_any`.
+The `any` varients are [`startswith_any`](@ref), [`endswith_any`](@ref),  and [`contains_any`](@ref).
 They are of the form:
 ```julia
 check_any(needles, haystack) == any(check(haystack, needle) for needle in needles)
@@ -40,7 +40,7 @@ check_any(needles, haystack) == any(check(haystack, needle) for needle in needle
 ## Examples
 
 Consider if I had a list of column names, to do with prices and weather in various cities.
-Where want city it is about is part of the column name, as what kind of data it is.
+Where the column names include the city and kind of data it is about.
 
 I might want just the columns names that are for a particular city:
 ```jldoctest symbol_searching

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -5,7 +5,7 @@ Often one thus wants to do various filters on `Symbol`s.
 
 Most filtering functions only accept strings, so code contains a lot of code like:
 ```julia
-filter(col_name->startswith(colname, "temperature"), Symbol.(names(df)))
+filter(col_name->startswith(colname, "temperature"), String.(names(df)))
 ```
 
 We solve that by making functions that accept `Symbol` for all the arguments that would otherwise be strings.

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -16,7 +16,7 @@ We add the missing ones.
 
 !!! warning "Type Piracy"
     We type-pirate `startwith` and `endswith` to provide the single argument, and `Symbol` accepting versions.
-    This is misdemeanor type-piracy: it only turns code which currently errors into nonerrors.
+    This is misdemeanor type-piracy: it only turns code which currently errors into non-errors.
     It is also the only reasonable definition for these methods.
     We don't type-pirate `occursin` as we replace that with [`contains`](@ref) which follows the consistent argument order.
 

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -39,19 +39,20 @@ check_any(needles, haystack) == any(check(haystack, needle) for needle in needle
 
 ## Examples
 
-Consider if I had a list of column names, to do with house prices and weather in various cities.
+Consider if I had a list of column names, to do with prices and weather in various cities.
 Where want city it is about is part of the column name, as what kind of data it is.
 
 I might want just the columns names that are for a particular city:
 ```jldoctest symbol_searching
 julia> using Wrangling
 
-julia> const column_names = [:NY_temperature, :NY_house_price, :NY_rainfall, :LON_temperature, :LON_house_price, :LON_rainfall];
+julia> const column_names = const column_names = [:NY_temperature, :NY_house_price, :NY_car_price, :NY_rainfall, :LON_temperature, :LON_house_price, :LON_car_price, :LON_rainfall];
 
 julia> const LON_cols = filter(startswith(:LON), column_names)
-3-element Array{Symbol,1}:
+4-element Array{Symbol,1}:
  :LON_temperature
  :LON_house_price
+ :LON_car_price
  :LON_rainfall
 ```
 
@@ -68,7 +69,31 @@ julia> const weather_cols = filter(contains_any((:temperature, :rainfall)), colu
 Or we might want to do the opposite and exclude any to do with weather:
 ```jldoctest symbol_searching
 julia> const nonweather_cols = filter(!contains_any((:temperature, :rainfall)), column_names)
-2-element Array{Symbol,1}:
+4-element Array{Symbol,1}:
  :NY_house_price
+ :NY_car_price
  :LON_house_price
+ :LON_car_price
+```
+
+Or I might want to get only price data for only one city.
+```jldoctest symbol_searching
+julia> const LON_prices = filter(contains(r"^LON_.*_price$"), column_names)
+2-element Array{Symbol,1}:
+ :LON_house_price
+ :LON_car_price
+```
+
+
+What if we want all columns that are for a particular city, or that are for rainfall:
+```jldoctest symbol_searching
+julia> const LON_or_rainfall_cols = filter(column_names) do col
+   startswith(col, :LON) || endswith(col, :rainfall)
+end
+5-element Array{Symbol,1}:
+ :NY_rainfall
+ :LON_temperature
+ :LON_house_price
+ :LON_car_price
+ :LON_rainfall
 ```

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -1,0 +1,74 @@
+# Working with Symbols
+
+Tables use `Symbol`s to represent column names.
+Often one thus wants to do various filters on `Symbol`s.
+
+Most filtering functions only accept strings, so code contains a lot of code like:
+```julia
+filter(col_name->startswith(colname, "tempurature"), Symbol.(names(df)))
+```
+
+We solve that by making functions that accept `Symbol` for all the arguments that would otherwise be strings.
+Similarly, while some functions like `isequal` and `in` have _curried_ varients, like `in(collection)` being the same as `item->in(item, collection)`,
+not all do.
+We add the missing ones.
+
+
+!!! warning Type Piracy
+    We type-pirate `startwith` and `endswith` to provide the single argument, and `Symbol` accepting versions.
+    This is misdemeanor type-piracy: it only turns code which currently errors into nonerrors.
+    Its also the only reasonable definition for these types.
+    We don't type-pirate `occursin` as we replace that with `` which follows the consistent argument order.
+
+
+### Functions:
+These are basically all varients of existing functions.
+
+ [`contains`](@ref)`(haystack, needle)` is an argument order reversed version of `occursin(needle, haystack)`. It matchs `startswith` and `endswith`.
+
+`contains`, `startswith`, `endswith`, and all their varients mentioned here, all accept symbols everywhere they might accept `String`s.
+
+The curried varients are `check(needle) == haystack->check(haystack, needle)`.
+We have them for `contains`, `startswith`, `endswith`, and all their varients.
+
+They any varients are `startswith_any`, `endswith_any`,  and `contains_any`.
+They are of the form:
+```julia
+check_any(needles, haystack) == any(check(haystack, needle) for needle in needles)
+```
+
+## Examples
+
+Consider if I had a list of column names, to do with house prices and weather in various cities.
+Where want city it is about is part of the column name, as what kind of data it is.
+
+I might want just the columns names that are for a particular city:
+```jldoctest symbol_searching
+julia> using Wrangling
+
+julia> const column_names = [:NY_temperature, :NY_house_price, :NY_rainfall, :LON_temperature, :LON_house_price, :LON_rainfall];
+
+julia> const LON_cols = filter(startswith(:LON), column_names)
+3-element Array{Symbol,1}:
+ :LON_temperature
+ :LON_house_price
+ :LON_rainfall
+```
+
+Another thing I might want to do, is get just the ones that are to do with weather.
+
+```jldoctest symbol_searching
+julia> const weather_cols = filter(contains_any((:temperature, :rainfall)), column_names)
+4-element Array{Symbol,1}:
+ :NY_temperature
+ :NY_rainfall
+ :LON_temperature
+ :LON_rainfall
+```
+Or we might want to do the opposite and exclude any to do with weather:
+```jldoctest symbol_searching
+julia> const nonweather_cols = filter(!contains_any((:temperature, :rainfall)), column_names)
+2-element Array{Symbol,1}:
+ :NY_house_price
+ :LON_house_price
+```

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -85,11 +85,9 @@ julia> const LON_prices = filter(contains(r"^LON_.*_price$"), column_names)
 ```
 
 
-What if we want all columns that are for a particular city, or that are for rainfall:
+What if we want all columns that are either for a particular city, or that are for rainfall anywhere:
 ```jldoctest symbol_searching
-julia> const LON_or_rainfall_cols = filter(column_names) do col
-   startswith(col, :LON) || endswith(col, :rainfall)
-end
+julia> const LON_or_rainfall_cols = filter(col -> startswith(col, :LON) || endswith(col, :rainfall), column_names)
 5-element Array{Symbol,1}:
  :NY_rainfall
  :LON_temperature

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -31,7 +31,7 @@ These are basically all varients of existing functions.
 The curried varients are `check(needle) == haystack->check(haystack, needle)`.
 We have them for `contains`, `startswith`, `endswith`, and all their varients.
 
-They any varients are `startswith_any`, `endswith_any`,  and `contains_any`.
+The any varients are `startswith_any`, `endswith_any`,  and `contains_any`.
 They are of the form:
 ```julia
 check_any(needles, haystack) == any(check(haystack, needle) for needle in needles)

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -22,7 +22,7 @@ We add the missing ones.
 
 
 ## Functions
-These are basically all varients of existing functions.
+These are basically all variants of existing functions.
 
  [`contains(haystack, needle)`](@ref contains) is an argument order reversed version of `occursin(needle, haystack)`. It matches `startswith` and `endswith`.
 

--- a/src/Wrangling.jl
+++ b/src/Wrangling.jl
@@ -1,5 +1,8 @@
 module Wrangling
 
-greet() = print("Hello World!")
+export contains
+export startswith_any, endswith_any, contains_any
+
+include("symbol_searching.jl")
 
 end # module

--- a/src/symbol_searching.jl
+++ b/src/symbol_searching.jl
@@ -1,0 +1,46 @@
+
+"""
+    contains(haystack, needle)
+
+This is the same as `Base.occurin(needle, haystack)`, just with the arguments reversed.
+This makes it line up with `startswith` and `endswith`.
+"""
+contains(haystack, needle) = occursin(needle, haystack)
+
+for (mod, f) in ((Base, :startswith), (Base, :endswith), (Wrangling, :contains))
+    # add Symbol overloads
+    @eval $mod.$f(haystack::Symbol, needle::Symbol) = $f(String(haystack), String(needle))
+    @eval $mod.$f(haystack, needle::Symbol) = $f(haystack, String(needle))
+    @eval $mod.$f(haystack::Symbol, needle) = $f(String(haystack), needle)
+
+    # add _any varients
+    @eval begin
+        """
+            $($f)_any(haystack, needles)
+
+        Given a list of `needles`, this returns `true`
+        if `$($f)` would return true for any needle in that list.
+        """
+        function $(Symbol(f, :_any))(haystack, needles)
+            return any($f(haystack, needle) for needle in needles)
+        end
+    end
+end
+
+# add curried varients
+for (needle_var, fs) in (
+    :needle => (:(Base.startswith), :(Base.endswith), :contains),
+    :needles => (:startswith_any, :endswith_any, :contains_any),
+    )
+    for f in fs
+        quote_nv = QuoteNode(needle_var)
+        @eval begin
+            """
+                $($f)($($quote_nv)) :: Function
+            Curried form of `$($f)(haystack, $($quote_nv))`
+            Creates a function that that checks wether its argument is $($f) $($quote_nv).
+            """
+            $f($needle_var) = Base.Fix2($f, $needle_var)
+        end
+    end
+end

--- a/src/symbol_searching.jl
+++ b/src/symbol_searching.jl
@@ -31,14 +31,13 @@ end
 for (needle_var, fs) in (
     :needle => (:(Base.startswith), :(Base.endswith), :contains),
     :needles => (:startswith_any, :endswith_any, :contains_any),
-    )
+)
     for f in fs
         quote_nv = QuoteNode(needle_var)
         @eval begin
             """
-                $($f)($($quote_nv)) :: Function
+                $($f)($($quote_nv)) -> Function
             Curried form of `$($f)(haystack, $($quote_nv))`
-            Creates a function that that checks wether its argument is $($f) $($quote_nv).
             """
             $f($needle_var) = Base.Fix2($f, $needle_var)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using Wrangling
 using Test
 
 @testset "Wrangling.jl" begin
-    # Write your own tests here.
+    include("symbol_searching.jl")
 end

--- a/test/symbol_searching.jl
+++ b/test/symbol_searching.jl
@@ -1,0 +1,68 @@
+# Performs tests on a checker considering a bunch of different transforms of the
+# needle and haystack
+function test_checker(
+    check::Function,
+    haystack::AbstractString,
+    right_needle,
+    wrong_needle,
+)
+
+    @testset "$check" begin
+        for (haystack_f, needle_f) in haystack_needle_transforms
+            test_checker1(
+                check,
+                transform(haystack_f, haystack),
+                transform(needle_f, right_needle),
+                transform(needle_f, wrong_needle),
+            )
+        end
+    end
+end
+
+const haystack_needle_transforms = Iterators.product(
+    (identity, Symbol),  # haystack
+    (identity, Symbol, first, Regex),  # needle
+)
+
+transform(f, x) = f(x)
+transform(f, x::Tuple) = map(f, x)  # for testing _any varients
+
+function test_checker1(
+    check::Function, haystack::H, right_needle::N, wrong_needle::N
+) where {H,N}
+    @testset "$H, $N" begin
+        @testset "2 arg form" begin
+            @test check(haystack, right_needle)
+            @test !check(haystack, wrong_needle)
+        end
+
+        @testset "curried form" begin
+            @test check(right_needle)(haystack)
+            @test !check(wrong_needle)(haystack)
+
+            @test (!check(wrong_needle))(haystack)  # check negated function
+        end
+    end
+end
+
+@testset "symbol_searching.jl" begin
+    @testset "basic varients" begin
+        test_checker(contains, "abc", "b", "x")
+        test_checker(startswith, "abc", "a", "b")
+        test_checker(endswith, "abc", "c", "b")
+    end
+
+    @testset "_any varients" begin
+        @testset "singleton tuple" begin
+            test_checker(contains_any, "abc", ("b",), ("x",))
+            test_checker(startswith_any, "abc", ("a",), ("b",))
+            test_checker(endswith_any, "abc", ("c",), ("b",))
+        end
+
+        @testset "right || wrong == right and wrong || wrong ==wrong" begin
+            test_checker(contains_any, "abc", ("b", "q"), ("x", "q"))
+            test_checker(startswith_any, "abc", ("a", "q"), ("b", "q"))
+            test_checker(endswith_any, "abc", ("c", "q"), ("b", "q"))
+        end
+    end
+end

--- a/test/symbol_searching.jl
+++ b/test/symbol_searching.jl
@@ -6,7 +6,6 @@ function test_checker(
     right_needle,
     wrong_needle,
 )
-
     @testset "$check" begin
         for (haystack_f, needle_f) in haystack_needle_transforms
             test_checker1(
@@ -27,6 +26,8 @@ const haystack_needle_transforms = Iterators.product(
 transform(f, x) = f(x)
 transform(f, x::Tuple) = map(f, x)  # for testing _any varients
 
+# Tests that the `check` function works correctly for these arguments
+# this is a single case whereas `test_check` generates a bunch of cases for different argument types
 function test_checker1(
     check::Function, haystack::H, right_needle::N, wrong_needle::N
 ) where {H,N}


### PR DESCRIPTION
Key features:
 
 - `contains(haystack, needle)`  that is like `occursin(needle, haystack)` but right way round
 - `contains`, `startswith`, `endswith` now all accept `Symbols`. (Misdemeanor type-piracy)
 - `contains_any`, `startswith_any`, `endswith_any`  that accept a list of needles and return true if any of them match
 - curried forms `check(needle) = haystack->check(needle, haystack)` for  `contains`, `startswith`, `endswith`, `contains_any`, `startswith_any`, `endswith_any` 