### PR TITLE
Use Compat for functions now in Base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,13 @@
 name = "Wrangling"
 uuid = "9e19721c-8a1a-4e7b-ae00-562464868f98"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.2"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
+Compat = "3.15"
 julia = "1"
 
 [extras]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -3,9 +3,19 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "215f1c81cfd1c5416cd78740bff8ef59b24cd7c0"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.15.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -13,15 +23,15 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
+git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.1"
+version = "0.8.3"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "d497bcc45bb98a1fbe19445a774cfafeabc6c6df"
+git-tree-sha1 = "fb1ff838470573adc15c71ba79f8d31328f035da"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.24.5"
+version = "0.25.2"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -34,10 +44,15 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -51,12 +66,12 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "d112c19ccca00924d5d3a38b11ae2b4b268dda39"
+git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.11"
+version = "1.0.10"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -77,8 +92,20 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -92,6 +119,7 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[Wrangling]]
+deps = ["Compat"]
 path = ".."
 uuid = "9e19721c-8a1a-4e7b-ae00-562464868f98"
-version = "0.1.0"
+version = "0.1.2"

--- a/docs/src/symbol_searching.md
+++ b/docs/src/symbol_searching.md
@@ -15,21 +15,16 @@ We add the missing ones.
 
 
 !!! warning "Type Piracy"
-    We type-pirate `startwith` and `endswith` to provide the single argument, and `Symbol` accepting versions.
+    We type-pirate `startwith` and `endswith` to provide `Symbol` accepting versions.
     This is misdemeanor type-piracy: it only turns code which currently errors into non-errors.
     It is also the only reasonable definition for these methods.
-    We don't type-pirate `occursin` as we replace that with [`contains`](@ref) which follows the consistent argument order.
 
 
 ## Functions
-These are basically all variants of existing functions.
 
- [`contains(haystack, needle)`](@ref contains) is an argument order reversed version of `occursin(needle, haystack)`. It matches `startswith` and `endswith`.
+These are all variants of existing functions.
 
 `contains`, `startswith`, `endswith`, and all their varients mentioned here, accept `Symbol`s everywhere they might accept `String`s.
-
-The curried varients are `check(needle) == haystack->check(haystack, needle)`.
-We have them for `contains`, `startswith`, `endswith`, and all their varients.
 
 The `any` varients are [`startswith_any`](@ref), [`endswith_any`](@ref),  and [`contains_any`](@ref).
 They are of the form:

--- a/src/Wrangling.jl
+++ b/src/Wrangling.jl
@@ -1,5 +1,7 @@
 module Wrangling
 
+using Compat: Compat, contains
+
 export contains
 export startswith_any, endswith_any, contains_any
 

--- a/src/symbol_searching.jl
+++ b/src/symbol_searching.jl
@@ -28,6 +28,7 @@ for f in (:startswith_any, :endswith_any, :contains_any)
     @eval begin
         """
             $($f)(needles) -> Function
+
         Curried form of `$($f)(haystack, needles)`
         """
         $f(needles) = Base.Fix2($f, needles)

--- a/src/symbol_searching.jl
+++ b/src/symbol_searching.jl
@@ -1,16 +1,4 @@
-# `contains` was added to Julia Base in 1.5.0-DEV.639
-# https://github.com/JuliaLang/julia/commit/cc6e121386758dff6ba7911770e48dfd59520199
-@static if VERSION <= v"1.5.0-DEV.639"
-    """
-        contains(haystack, needle)
-
-    This is the same as `Base.occurin(needle, haystack)`, just with the arguments reversed.
-    This makes it line up with `startswith` and `endswith`.
-    """
-    contains(haystack, needle) = occursin(needle, haystack)
-end
-
-for (mod, f) in ((Base, :startswith), (Base, :endswith), (Wrangling, :contains))
+for (mod, f) in ((Base, :startswith), (Base, :endswith), (Compat, :contains))
     # add Symbol overloads
     @eval $mod.$f(haystack::Symbol, needle::Symbol) = $f(String(haystack), String(needle))
     @eval $mod.$f(haystack::Symbol, needle) = $f(String(haystack), needle)
@@ -43,22 +31,5 @@ for f in (:startswith_any, :endswith_any, :contains_any)
         Curried form of `$($f)(haystack, needles)`
         """
         $f(needles) = Base.Fix2($f, needles)
-    end
-end
-
-# curried version of `startswith` and `endswith` add to Julia Base in 1.5.0-DEV.438
-# https://github.com/JuliaLang/julia/commit/0a43c0f1d21ce9c647c49111d93927369cd20f85
-# `contains` was added to Julia Base in 1.5.0-DEV.639
-# https://github.com/JuliaLang/julia/commit/cc6e121386758dff6ba7911770e48dfd59520199
-@static if VERSION <= v"1.5.0-DEV.639"
-    for f in (:(Base.startswith), :(Base.endswith), :contains)
-        @eval begin
-            """
-                $($f)(needle) -> Function
-
-            Curried form of `$($f)(haystack, needle)`
-            """
-            $f(needle) = Base.Fix2($f, needle)
-        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Compat: contains
 using Wrangling
 using Test
 


### PR DESCRIPTION
- Requires Compat.jl v3.15 to be released
- Closes #4 and #14 
- This adds a little bit to compile time, but simplifies code in this package and it's still very snappy (`~0.64s` -> `~0.68s`)