### PR TITLE
Pin Docs Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.5'
       - run: |
           julia --project=docs -e '
             using Pkg


### PR DESCRIPTION
Docs should always pin Julia version so that printing changes don't cause random failures.

